### PR TITLE
Fix missing `fetch-depth` in checkout action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,7 @@ runs:
   steps:
     - uses: actions/checkout@v4
       with:
+        fetch-depth: 10
         token: ${{ inputs.github_token }}
     - uses: dependabot/fetch-metadata@v2
       id: metadata


### PR DESCRIPTION
2 would be sufficient, but I set it to 10 to allow some margin for when multiple commits accumulate.
