### PR TITLE
Fix bug on multiple dependencies update

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,12 +16,20 @@ runs:
       id: metadata
       with:
         github-token: ${{ inputs.github-token }}
+    - name: Convert to dependency names no comma
+      if: ${{ steps.metadata.outputs.package-ecosystem == 'bundler' }}
+      id: convert-dependency-names
+      run: |
+        original_dependency_names="${{ steps.metadata.outputs.dependency-names }}"
+        converted_dependency_names="${original_dependency_names//,/ }"
+        echo "value=${converted_dependency_names}" >> "$GITHUB_OUTPUT"
+      shell: bash
     - if: ${{ steps.metadata.outputs.package-ecosystem == 'bundler' }}
       uses: ruby/setup-ruby@v1
     - if: ${{ steps.metadata.outputs.package-ecosystem == 'bundler' }}
       run: |
         git checkout HEAD~ -- Gemfile.lock
-        bundle lock --conservative --update "${{ steps.metadata.outputs.dependency-names }}"
+        bundle lock --conservative --update ${{ steps.convert-dependency-names.outputs.value }}
       env:
         BUNDLE_FROZEN: "false"
       shell: bash


### PR DESCRIPTION
The dependency-names from Dependabot metadata contains comma-separated values when there are multiple dependencies (ex: Dependabot group patterns).

https://github.com/dependabot/fetch-metadata/blob/5a70a1d133aebc31503dc07fb19f294cf18ff31c/src/dependabot/output.ts#L17-L19

The bundle lock --update command cannot handle the comma-separated format correctly.
So, a new step is added to remove commas before passing to the command.